### PR TITLE
[WIP] Adding SNS endpoint support for alerting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
+  t.warning = false
 end
 
 task :default => :test

--- a/bin/deadman-check
+++ b/bin/deadman-check
@@ -29,7 +29,11 @@ command :switch_monitor do |c|
   c.option '--daemon', 'Run as a daemon, otherwise will run check just once'
   c.option '--daemon-sleep SECONDS', String, 'Set the number of seconds to sleep in between switch checks, default 300'
   c.action do |args, options|
-    options.default :daemon_sleep => 300, :alert_to_sns_region => 'us-west-2'
+    options.default :daemon_sleep => 300,
+                    :alert_to_sns_region => 'us-west-2',
+                    :alert_to_sns => nil,
+                    :alert_to_slack => nil
+                    
     if options.key_path && options.key
       abort("Specify --key-path or --key, don't specify both")
     end

--- a/bin/deadman-check
+++ b/bin/deadman-check
@@ -14,18 +14,22 @@ command :switch_monitor do |c|
   c.summary = 'Target a Consul key to monitor'
   c.description = 'switch_monitor will monitor either a given key which contains a services last epoch checkin and frequency, or a series of services that set keys under a given key-path in Consul'
   c.example %q{Target a Consul key deadman/myservice, and this key has an EPOCH value to check looking to alert},
-    %q{deadman-check switch_monitor --host 127.0.0.1 --port 8500 --key deadman/myservice --alert-to monitoroom}
+    %q{deadman-check switch_monitor --host 127.0.0.1 --port 8500 --key deadman/myservice --alert-to-slack my-slack-monitor-channel}
   c.example %q{Target a Consul key path deadman/, which contains 2 or more service keys to monitor, i.e. deadman/myservice1, deadman/myservice2, deadmman/myservice3 all fall under the path deadman/},
-    %q{deadman-check switch_monitor --host 127.0.0.1 --port 8500 --key-path deadman/ --alert-to monitoroom}
+    %q{deadman-check switch_monitor --host 127.0.0.1 --port 8500 --key-path deadman/ --alert-to-slack my-slack-monitor-channel}
+  c.example %q{Target a Consul key path deadman/, alert to Amazon SNS, i.e. deadman/myservice1, deadman/myservice2, deadmman/myservice3 all fall under the path deadman/},
+    %q{deadman-check switch_monitor --host 127.0.0.1 --port 8500 --key-path deadman/ --alert-to-sns arn:aws:sns:*:123456789012:my_corporate_topic}
   c.option '--host HOST', String, 'IP address or hostname of Consul system'
   c.option '--port PORT', String, 'port Consul is listening on'
   c.option '--key-path KEYPATH', String, 'Consul key path to monitor, performs a recursive key lookup at given path.'
   c.option '--key KEY', String, 'Consul key to monitor, provide this or --key-path if you have multiple keys in a given path.'
-  c.option '--alert-to SLACKROOM', String, 'Slackroom to send alert, don\'t include the # tag in name'
+  c.option '--alert-to-slack SLACKCHANNEL', String, 'Slack channel to send alert, don\'t include the # tag in name'
+  c.option '--alert-to-sns SNSARN', String, 'Amazon Web Services SNS arn to send alert, example arn arn:aws:sns:*:123456789012:my_corporate_topic'
+  c.option '--alert-to-sns-region AWSREGION', String, 'Amazon Web Services region the SNS topic is in, defaults to us-west-2'
   c.option '--daemon', 'Run as a daemon, otherwise will run check just once'
   c.option '--daemon-sleep SECONDS', String, 'Set the number of seconds to sleep in between switch checks, default 300'
   c.action do |args, options|
-    options.default :daemon_sleep => 300
+    options.default :daemon_sleep => 300, :alert_to_sns_region => 'us-west-2'
     if options.key_path && options.key
       abort("Specify --key-path or --key, don't specify both")
     end
@@ -36,8 +40,10 @@ command :switch_monitor do |c|
       target = options.key_path
       recurse = true
     end
-    switch_monitor = DeadmanCheck::SwitchMonitor.new(options.host, options.port,
-      target, options.alert_to, recurse, options.daemon_sleep)
+    switch_monitor = DeadmanCheck::SwitchMonitor.new(
+      options.host, options.port,
+      target, options.alert_to_slack, options.alert_to_sns,
+      options.alert_to_sns_region, recurse, options.daemon_sleep)
     if options.daemon
       Daemons.run(switch_monitor.run_check_daemon)
     else

--- a/bin/deadman-check
+++ b/bin/deadman-check
@@ -67,6 +67,12 @@ command :key_set do |c|
   c.option '--key KEY', String, 'Consul key to report EPOCH time and frequency for service'
   c.option '--frequency FREQUENCY', String, 'Frequency at which this key should be updated in seconds'
   c.action do |args, options|
+    if options.frequency.nil?
+      abort("Specify --frequency at which this key should be updated by the service")
+    end
+    if options.key.nil?
+      abort("Must specify a --key")
+    end
     key_set = DeadmanCheck::KeySet.new(options.host, options.port, options.key,
       options.frequency)
     key_set.run_consul_key_update

--- a/bin/deadman-check
+++ b/bin/deadman-check
@@ -33,7 +33,7 @@ command :switch_monitor do |c|
                     :alert_to_sns_region => 'us-west-2',
                     :alert_to_sns => nil,
                     :alert_to_slack => nil
-                    
+
     if options.key_path && options.key
       abort("Specify --key-path or --key, don't specify both")
     end

--- a/deadman_check.gemspec
+++ b/deadman_check.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diplomat', '~> 1.2', '>= 1.2.0'
   spec.add_dependency 'slack-ruby-client', '~> 0.8.0'
   spec.add_dependency 'daemons', '~> 1.2.4', '>=1.2.4'
+  spec.add_dependency 'aws-sdk', '~> 2.10.21', '>=2.10.21'
 end

--- a/deadman_check.gemspec
+++ b/deadman_check.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.0"
 
   spec.add_dependency 'commander', '~> 4.4', '>= 4.4.3'
-  spec.add_dependency 'diplomat', '~> 1.2', '>= 1.2.0'
+  spec.add_dependency 'diplomat', '~> 2.0.0', '>= 2.0.0'
   spec.add_dependency 'slack-ruby-client', '~> 0.8.0'
   spec.add_dependency 'daemons', '~> 1.2.4', '>=1.2.4'
   spec.add_dependency 'aws-sdk', '~> 2.10.21', '>=2.10.21'

--- a/lib/deadman_check/version.rb
+++ b/lib/deadman_check/version.rb
@@ -1,3 +1,3 @@
 module DeadmanCheck
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/lib/deadman_check_global.rb
+++ b/lib/deadman_check_global.rb
@@ -15,27 +15,4 @@ module DeadmanCheck
       end
     end
   end
-
-  class DeadmanCheckSlackAuth
-    Slack.configure do |config|
-      config.token = ENV['SLACK_API_TOKEN']
-    end
-  end
-
-  class DeadmanCheckSnsAuth
-    attr_accessor :region_name
-
-    # Default credentials are loaded automatically from the following locations:
-    # 1. ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
-    # 2. The shared credentials ini file at ~/.aws/credentials (more information)
-    # 3. From an instance profile when running on EC2
-    
-    def initialize(region_name)
-      @region_name = region_name
-    end
-
-    sns = Aws::SNS::Client.new(
-      region_name: region_name
-      )
-  end
 end

--- a/lib/deadman_check_global.rb
+++ b/lib/deadman_check_global.rb
@@ -15,4 +15,27 @@ module DeadmanCheck
       end
     end
   end
+
+  class DeadmanCheckSlackAuth
+    Slack.configure do |config|
+      config.token = ENV['SLACK_API_TOKEN']
+    end
+  end
+
+  class DeadmanCheckSnsAuth
+    attr_accessor :region_name
+
+    # Default credentials are loaded automatically from the following locations:
+    # 1. ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
+    # 2. The shared credentials ini file at ~/.aws/credentials (more information)
+    # 3. From an instance profile when running on EC2
+    
+    def initialize(region_name)
+      @region_name = region_name
+    end
+
+    sns = Aws::SNS::Client.new(
+      region_name: region_name
+      )
+  end
 end

--- a/lib/deadman_check_switch.rb
+++ b/lib/deadman_check_switch.rb
@@ -9,10 +9,7 @@ module DeadmanCheck
   # Switch class
   class SwitchMonitor
     attr_accessor :host, :port, :target, :alert_to_slack,
-      :alert_to_sns, :alert_to_sns_region, :recurse, :daemon_sleep
-
-    @alert_to_slack = nil
-    @alert_to_sns = nil
+    :alert_to_sns, :alert_to_sns_region, :recurse, :daemon_sleep
 
     def initialize(host, port, target, alert_to_slack, alert_to_sns,
                   alert_to_sns_region, recurse, daemon_sleep)
@@ -24,18 +21,18 @@ module DeadmanCheck
       @alert_to_sns_region = alert_to_sns_region
       @recurse = recurse
       @daemon_sleep = daemon_sleep.to_i
-    end
 
-    unless @alert_to_slack.nil?
-      Slack.configure do |config|
-        config.token = ENV['SLACK_API_TOKEN']
+      unless @alert_to_slack.nil?
+        Slack.configure do |config|
+          config.token = ENV['SLACK_API_TOKEN']
+        end
       end
-    end
 
-    unless @alert_to_sns.nil?
-      @sns = Aws::SNS::Client.new(
-        region: @alert_to_sns_region
-        )
+      unless @alert_to_sns.nil?
+        @sns = Aws::SNS::Client.new(
+          region: @alert_to_sns_region
+          )
+      end
     end
 
     def run_check_once
@@ -117,10 +114,10 @@ module DeadmanCheck
           target_arn: @alert_to_sns,
           message_structure: 'json',
           message: {
-            default => "Alert: Deadman Switch triggered for #{target}",
-            email => "Alert: Deadman Switch triggered for #{target}, with
+            :default => "Alert: Deadman Switch triggered for #{target}",
+            :email => "Alert: Deadman Switch triggered for #{target}, with
             #{epoch_diff} seconds since last run",
-            sms => "Alert: Deadman Switch for #{target}"
+            :sms => "Alert: Deadman Switch for #{target}"
           }.to_json
         )
       end

--- a/lib/deadman_check_switch.rb
+++ b/lib/deadman_check_switch.rb
@@ -76,9 +76,9 @@ module DeadmanCheck
       def alert_if_epoch_greater_than_frequency(epoch_diff, target, frequency)
         if epoch_diff > frequency
           slack_alert(
-            @alert_to_slack, target, epoch_diff) unless alert_to_slack.nil?
+            @alert_to_slack, target, epoch_diff) unless @alert_to_slack.nil?
           sns_alert(
-            @alert_to_sns, target, epoch_diff) unless alert_to_sns.nil?
+            @alert_to_sns, target, epoch_diff) unless @alert_to_sns.nil?
         end
       end
 

--- a/lib/deadman_check_switch.rb
+++ b/lib/deadman_check_switch.rb
@@ -65,30 +65,6 @@ module DeadmanCheck
         return recorded_epochs
       end
 
-      def parse_recorded_epoch(recorded_epochs)
-        # {"epoch":1493000501,"frequency":"300"}
-        value_json = JSON.parse(recorded_epochs[0][:value])
-        frequency = value_json["frequency"]
-        epoch = value_json["epoch"]
-        return epoch, frequency
-      end
-
-      def alert_if_epoch_greater_than_frequency(epoch_diff, target, frequency)
-        if epoch_diff > frequency
-          slack_alert(
-            @alert_to_slack, target, epoch_diff) unless @alert_to_slack.nil?
-          sns_alert(
-            @alert_to_sns, target, epoch_diff) unless @alert_to_sns.nil?
-        end
-      end
-
-      def check_recorded_epoch(parse_recorded_epoch, current_epoch)
-        recorded_epoch = parse_recorded_epoch[0].to_i
-        frequency = parse_recorded_epoch[1].to_i
-        epoch_diff = diff_epoch(current_epoch, recorded_epoch)
-        alert_if_epoch_greater_than_frequency(epoch_diff, @target, frequency)
-      end
-
       def check_recursive_recorded_epochs(recorded_epochs, current_epoch)
         recorded_epochs.each do |recorded_service|
           value_json = JSON.parse(recorded_service[:value])
@@ -98,6 +74,30 @@ module DeadmanCheck
           alert_if_epoch_greater_than_frequency(epoch_diff,
                                                 recorded_service[:key],
                                                 frequency)
+        end
+      end
+
+      def parse_recorded_epoch(recorded_epochs)
+        # {"epoch":1493000501,"frequency":"300"}
+        value_json = JSON.parse(recorded_epochs[0][:value])
+        frequency = value_json["frequency"]
+        epoch = value_json["epoch"]
+        return epoch, frequency
+      end
+
+      def check_recorded_epoch(parse_recorded_epoch, current_epoch)
+        recorded_epoch = parse_recorded_epoch[0].to_i
+        frequency = parse_recorded_epoch[1].to_i
+        epoch_diff = diff_epoch(current_epoch, recorded_epoch)
+        alert_if_epoch_greater_than_frequency(epoch_diff, @target, frequency)
+      end
+
+      def alert_if_epoch_greater_than_frequency(epoch_diff, target, frequency)
+        if epoch_diff > frequency
+          slack_alert(
+            @alert_to_slack, target, epoch_diff) unless @alert_to_slack.nil?
+          sns_alert(
+            @alert_to_sns, target, epoch_diff) unless @alert_to_sns.nil?
         end
       end
 

--- a/test/deadman_check_test.rb
+++ b/test/deadman_check_test.rb
@@ -52,7 +52,7 @@ class DeadmanCheckTest < Minitest::Test
     refute_nil ::DeadmanCheck::VERSION
   end
 
-  def test_consul_key_update
+  def test_consul_key_update_slack
     stub_request(:put, "http://127.0.0.1:8500/v1/kv/test").
       with(body: "{\"epoch\":#{Time.now.to_i},\"frequency\":\"300\"}").
       to_return(status: 200, body: "", headers: {})
@@ -61,23 +61,23 @@ class DeadmanCheckTest < Minitest::Test
     key_set.run_consul_key_update
   end
 
-  def test_recursive_key_lookup
+  def test_recursive_key_lookup_slack
     stub_request(:get, "http://127.0.0.1:8500/v1/kv/deadman/?recurse").
       to_return(status: 200, body: @@recursive_key_response, headers: {})
     stub_request(:post, "https://slack.com/api/chat.postMessage").
       to_return(status: 200, body: "{\"ok\":true}", headers: {})
     switch_monitor = DeadmanCheck::SwitchMonitor.new('127.0.0.1', '8500',
-      'deadman/', 'monitoroom', true, '30')
+      'deadman/', 'monitoroom', nil, nil, true, '30')
     switch_monitor.run_check_once
   end
 
-  def test_standalone_key_lookup
+  def test_standalone_key_lookup_slack
     stub_request(:get, "http://127.0.0.1:8500/v1/kv/deadman/myservice1").
       to_return(status: 200, body: @@standalone_key_response, headers: {})
     stub_request(:post, "https://slack.com/api/chat.postMessage").
       to_return(status: 200, body: "{\"ok\":true}", headers: {})
     switch_monitor = DeadmanCheck::SwitchMonitor.new('127.0.0.1', '8500',
-      'deadman/myservice1', 'monitoroom', false, '30')
+      'deadman/myservice1', 'monitoroom', nil, nil, false, '30')
     switch_monitor.run_check_once
   end
 end


### PR DESCRIPTION
Move alerting options into global name space

Enable Amazon Web Services SNS as a possible alerting endpoint